### PR TITLE
Install Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ reports/
 selenium-debug.log
 screenshots/
 .DS_Store
+phantomjsdriver.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - 6.4.0
 script:
 - npm test
+- npm run setup-selenium
 - npm run example &
 - npm run e2e
 deploy:

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "watch": "webpack -p --config webpack.config.js --watch",
     "example": "NODE_ENV=DEVELOPMENT webpack-dev-server --content-base example/ --config example/webpack.config.js --progress --colors",
     "e2e": "./node_modules/nightwatch/bin/nightwatch",
-    "postinstall": "node scripts/download_selenium.js",
+    "setup-selenium": "node scripts/download_selenium.js",
     "prepublish": "npm run build"
   },
   "author": "Autodesk Bio/Nano",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "molecule-3d-for-react",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "3D molecule visualization with React and 3Dmol.js",
   "main": "dist/bundle.js",
   "files": [


### PR DESCRIPTION
Selenium was being downloaded during a normal `npm install`, which was totally unintended for regular users of this library.  This removes that command so it only runs automatically with Travis.