### PR TITLE
Callback on render change to override zoom behaviour if desired

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Indicates an orbital to display using 3Dmol.js's [addIsosurface method](http://3
       opacity,
     }
 
+###  onRenderNewData {function} [(glviewer) => {}]
+A callback for when the modelData has changed and it has been re-rendered in the viewer.
+
 ## Example
 
 <img src="https://raw.githubusercontent.com/Autodesk/molecule-3d-for-react/master/doc/example_screenshot.png" alt="screen shot" width="400" />

--- a/src/components/molecule_3d.jsx
+++ b/src/components/molecule_3d.jsx
@@ -17,7 +17,7 @@ class Molecule3d extends React.Component {
     backgroundOpacity: 1.0,
     backgroundColor: '#73757c',
     height: '500px',
-    onRenderNewData: (glviewer) => {},
+    onRenderNewData: () => {},
     orbital: {},
     selectedAtomIds: [],
     selectionType: selectionTypesConstants.ATOM,

--- a/src/components/molecule_3d.jsx
+++ b/src/components/molecule_3d.jsx
@@ -17,6 +17,10 @@ class Molecule3d extends React.Component {
     backgroundOpacity: 1.0,
     backgroundColor: '#73757c',
     height: '500px',
+    onRenderNewData: (glviewer) => {
+      glviewer.zoomTo();
+      glviewer.zoom(0.8, 2000);
+    },
     orbital: {},
     selectedAtomIds: [],
     selectionType: selectionTypesConstants.ATOM,
@@ -35,6 +39,7 @@ class Molecule3d extends React.Component {
       bonds: React.PropTypes.array,
     }).isRequired,
     onChangeSelection: React.PropTypes.func,
+    onRenderNewData: React.PropTypes.func,
     orbital: React.PropTypes.shape({
       cube_file: React.PropTypes.string,
       iso_val: React.PropTypes.number,
@@ -215,8 +220,7 @@ class Molecule3d extends React.Component {
     glviewer.render();
 
     if (!renderingSameModelData) {
-      glviewer.zoomTo();
-      glviewer.zoom(0.8, 2000);
+      this.props.onRenderNewData(glviewer);
     }
 
     this.oldModelData = this.props.modelData;

--- a/src/components/molecule_3d.jsx
+++ b/src/components/molecule_3d.jsx
@@ -17,10 +17,7 @@ class Molecule3d extends React.Component {
     backgroundOpacity: 1.0,
     backgroundColor: '#73757c',
     height: '500px',
-    onRenderNewData: (glviewer) => {
-      glviewer.zoomTo();
-      glviewer.zoom(0.8, 2000);
-    },
+    onRenderNewData: (glviewer) => {},
     orbital: {},
     selectedAtomIds: [],
     selectionType: selectionTypesConstants.ATOM,

--- a/test/components/molecule_3d_spec.js
+++ b/test/components/molecule_3d_spec.js
@@ -7,16 +7,27 @@ import sinon from 'sinon';
 import { mount } from 'enzyme';
 import Molecule3d from '../../src/components/molecule_3d';
 import bipyridineModelData from '../../example/js/bipyridine_model_data';
+import threeAidModelData from '../../example/js/3aid_model_data';
 import factories from '../fixtures/factories';
 
 const $3Dmol = require('3dmol');
 
 describe('Molecule3d', () => {
   const modelData = bipyridineModelData;
+  const modelData2 = threeAidModelData;
+  const emptyModelData = { atoms: [], bonds: [] };
   let renderer;
+  let glViewer;
 
   beforeEach(() => {
     renderer = ReactTestUtils.createRenderer();
+
+    glViewer = factories.getGlViewer();
+    sinon.stub($3Dmol, 'createViewer').callsFake(() => glViewer);
+  });
+
+  afterEach(() => {
+    $3Dmol.createViewer.restore();
   });
 
   describe('render', () => {
@@ -27,17 +38,40 @@ describe('Molecule3d', () => {
     });
   });
 
-  describe('render3dMol', () => {
-    let glViewer;
-
-    beforeEach(() => {
-      glViewer = factories.getGlViewer();
-      sinon.spy(glViewer, 'addLabel');
-      sinon.stub($3Dmol, 'createViewer').callsFake(() => glViewer);
+  describe('onRenderNewData', () => {
+    it('calls onRenderNewData for initial modelData', () => {
+      const callback = sinon.spy();
+      mount(<Molecule3d onRenderNewData={callback} modelData={modelData} />)
+      expect(callback.callCount).to.equal(1);
+      expect(callback.calledWith(glViewer)).to.equal(true);
     });
 
-    afterEach(() => {
-      $3Dmol.createViewer.restore();
+    it('calls onRenderNewData when modelData changed', () => {
+      const callback = sinon.spy();
+      const wrapper = mount(<Molecule3d onRenderNewData={callback} modelData={modelData} />);
+      wrapper.setProps({ modelData: modelData2 });
+      expect(callback.callCount).to.equal(2);
+      expect(callback.calledWith(glViewer)).to.equal(true);
+    });
+
+    it('doesn\'t call onRenderNewData when modelData not changed', () => {
+      const callback = sinon.spy();
+      const wrapper = mount(<Molecule3d atomLabelsShown={false} onRenderNewData={callback} modelData={modelData} />);
+      wrapper.setProps({ modelData, atomLabelsShown: true }); // Need a changed property to force re-render
+      expect(callback.callCount).to.equal(1);
+      expect(callback.calledWith(glViewer)).to.equal(true);
+    });
+
+    it('doesn\'t call onRenderNewData when empty modelData supplied', () => {
+      const callback = sinon.spy();
+      mount(<Molecule3d onRenderNewData={callback} modelData={emptyModelData} />);
+      expect(callback.callCount).to.equal(0);
+    });
+  });
+
+  describe('render3dMol', () => {
+    beforeEach(() => {
+      sinon.spy(glViewer, 'addLabel');
     });
 
     describe('when atomLabelsShown is true', () => {
@@ -73,7 +107,7 @@ describe('Molecule3d', () => {
       it('removes all viewer models', () => {
         const wrapper = mount(<Molecule3d modelData={modelData} />);
         expect(wrapper.node.glviewer.getModel()).to.not.equal(null);
-        wrapper.setProps({ modelData: { atoms: [], bonds: [] } });
+        wrapper.setProps({ modelData: emptyModelData });
         expect(wrapper.node.glviewer.getModel()).to.equal(null);
       });
     });


### PR DESCRIPTION
In our use case we change the modelData a fair bit. The default behaviour is to do a zoom into the model every time this happens, so there are repeated zooms in our app but we just want it to be static.

I've added a callback which by default maintains the zooming behaviour you had in place, but can be overridden to remove it.

IMO it probably makes more sense to have no zooming as the default behaviour then this callback for custom zooming behaviour, but I'll leave that decision up to you :)