### PR TITLE
Remove rendering when empty model data set on component

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -34,6 +34,11 @@ module.exports = function(config) {
 
 
     webpack: {
+      externals: {
+        "react/lib/ExecutionEnvironment": true,
+        "react/lib/ReactContext": true,
+        "react/addons": true
+      },
       resolve: {
         extensions: ['', '.js', '.jsx'],
       },
@@ -45,6 +50,9 @@ module.exports = function(config) {
           test: /\.scss$/,
           include: /example\/css/,
           loaders: ['style', 'css', 'sass'],
+        }, {
+          test: /\.json$/,
+          loader: 'json',
         }]
       }
     },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "sinon": "^2.0.0-pre.2",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.2",
-    "webpack-dev-server": "^1.16.2"
+    "webpack-dev-server": "^1.16.2",
+    "enzyme": "^2.7.1",
+    "json-loader": "^0.5.4"
   },
   "scripts": {
     "test": "karma start --single-run",

--- a/src/components/molecule_3d.jsx
+++ b/src/components/molecule_3d.jsx
@@ -51,8 +51,16 @@ class Molecule3d extends React.Component {
     width: React.PropTypes.string,
   }
 
+  static isModelDataEmpty(modelData) {
+    return modelData.atoms.length === 0 && modelData.bonds.length === 0;
+  }
+
   static render3dMolModel(glviewer, modelData) {
     glviewer.clear();
+
+    if (Molecule3d.isModelDataEmpty(modelData)) {
+      return;
+    }
 
     glviewer.addModel(moleculeUtils.modelDataToCDJSON(modelData), 'json', {
       keepH: true,
@@ -136,8 +144,7 @@ class Molecule3d extends React.Component {
   }
 
   render3dMol() {
-    if (!this.props.modelData.atoms.length ||
-        !this.props.modelData.bonds.length) {
+    if (!this.glviewer && Molecule3d.isModelDataEmpty(this.props.modelData)) {
       return;
     }
 

--- a/test/components/molecule_3d_spec.js
+++ b/test/components/molecule_3d_spec.js
@@ -4,6 +4,7 @@ import React from 'react';
 import ReactTestUtils from 'react-addons-test-utils';
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { mount } from 'enzyme';
 import Molecule3d from '../../src/components/molecule_3d';
 import bipyridineModelData from '../../example/js/bipyridine_model_data';
 import factories from '../fixtures/factories';
@@ -65,6 +66,15 @@ describe('Molecule3d', () => {
       it('removes all labels', () => {
         expect(glViewer.addLabel.called).to.equal(false);
         expect(glViewer.removeAllLabels.calledOnce).to.equal(true);
+      });
+    });
+
+    describe('when emptying modelData after set', () => {
+      it('removes all viewer models', () => {
+        const wrapper = mount(<Molecule3d modelData={modelData} />);
+        expect(wrapper.node.glviewer.getModel()).to.not.equal(null);
+        wrapper.setProps({ modelData: { atoms: [], bonds: [] } });
+        expect(wrapper.node.glviewer.getModel()).to.equal(null);
       });
     });
   });

--- a/test/fixtures/factories.js
+++ b/test/fixtures/factories.js
@@ -1,13 +1,18 @@
 const factories = {
   // 3dMol's glViewer class
   getGlViewer() {
+    let model = null;
     return {
       addLabel: () => {},
-      addModel: () => {},
-      clear: () => {},
-      getModel: () => ({
-        selectedAtoms: () => [],
-      }),
+      addModel: () => {
+        model = {
+          selectedAtoms: () => [],
+        };
+      },
+      clear: () => {
+        model = null;
+      },
+      getModel: () => model,
       removeAllLabels: () => {},
       removeAllShapes: () => {},
       render: () => {},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,10 @@ module.exports = {
         include: /example\/css/,
         loaders: ['style', 'css', 'sass'],
       },
+      {
+        test: /\.json$/,
+        loader: 'json-loader',
+      },
     ],
   },
   plugins: [


### PR DESCRIPTION
There was a bug where when you change the modelData to an empty instance (i.e. `{ atoms: [], bonds: [] }`) the previously rendered model isn't removed. This can quickly be verified in `npm run example`.