### PR TITLE
Fix deprecation warning from sinon

### DIFF
--- a/test/components/molecule_3d_spec.js
+++ b/test/components/molecule_3d_spec.js
@@ -32,7 +32,7 @@ describe('Molecule3d', () => {
     beforeEach(() => {
       glViewer = factories.getGlViewer();
       sinon.spy(glViewer, 'addLabel');
-      sinon.stub($3Dmol, 'createViewer', () => glViewer);
+      sinon.stub($3Dmol, 'createViewer').callsFake(() => glViewer);
     });
 
     afterEach(() => {


### PR DESCRIPTION
Not sure when it was introduced, but you can [see the message in the source](https://github.com/sinonjs/sinon/blob/4c6b875c96e8cd3efea18b1e28f2f55186c92065/lib/sinon/stub-descriptor.js#L13-L18):

> sinon.stub(obj, 'meth', fn) is deprecated and will be removed fromthe public API in a future version of sinon.
> Use stub(obj, 'meth').callsFake(fn).
> Codemod available at https://github.com/hurrymaplelad/sinon-codemod