### PR TITLE
Add properties for clipping planes and 3d shape outlines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: node_js
 node_js:
 - 6.4.0
+jdk:
+- oraclejdk8
 script:
 - npm test
+- java -version
 - npm run setup-selenium
 - npm run example &
 - npm run e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 addons:
   apt:
     packages:
-      - oracle-java8-installer
+      - oracle-java8-set-default
 script:
 - npm test
 - java -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 node_js:
 - 6.4.0
-language: java
-jdk:
-- oraclejdk8
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 script:
 - npm test
 - java -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - 6.4.0
+language: java
 jdk:
 - oraclejdk8
 script:

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "raw-loader": "^0.5.1",
     "react-addons-test-utils": "^15.3.2",
     "sass-loader": "^3.2.0",
-    "selenium-download": "^2.0.6",
+    "selenium-download": "^2.0.10",
     "sinon": "^2.0.0-pre.2",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "json-loader": "^0.5.4"
   },
   "scripts": {
-    "test": "java -version && karma start --single-run",
+    "test": "karma start --single-run",
     "tdd": "karma start",
     "build": "webpack -p --config webpack.config.js",
     "watch": "webpack -p --config webpack.config.js --watch",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "json-loader": "^0.5.4"
   },
   "scripts": {
-    "test": "karma start --single-run",
+    "test": "java -version && karma start --single-run",
     "tdd": "karma start",
     "build": "webpack -p --config webpack.config.js",
     "watch": "webpack -p --config webpack.config.js --watch",

--- a/src/components/molecule_3d.jsx
+++ b/src/components/molecule_3d.jsx
@@ -24,6 +24,10 @@ class Molecule3d extends React.Component {
     shapes: [],
     styles: {},
     width: '500px',
+    outlineWidth: 0.0,
+    outlineColor: '#000000',
+    nearClip: null,
+    farClip: null,
   }
 
   static propTypes = {
@@ -51,6 +55,10 @@ class Molecule3d extends React.Component {
     shapes: React.PropTypes.arrayOf(React.PropTypes.object),
     styles: React.PropTypes.objectOf(React.PropTypes.object),
     width: React.PropTypes.string,
+    nearClip: React.PropTypes.number,
+    farClip: React.PropTypes.number,
+    outlineWidth: React.PropTypes.number,
+    outlineColor: React.PropTypes.string,
   }
 
   static isModelDataEmpty(modelData) {
@@ -109,6 +117,8 @@ class Molecule3d extends React.Component {
     this.state = {
       selectedAtomIds: props.selectedAtomIds,
     };
+
+    this.lastOutline = { width: 0.0 };
   }
 
   componentDidMount() {
@@ -150,9 +160,15 @@ class Molecule3d extends React.Component {
       return;
     }
 
-    const glviewer = this.glviewer || $3Dmol.createViewer(jQuery(this.container), {
-      defaultcolors: $3Dmol.elementColors.rasmol,
-    });
+    let glviewer = null;
+
+    if (this.glviewer) {
+      glviewer = this.glviewer;
+    } else {
+      glviewer = $3Dmol.createViewer(
+        jQuery(this.container),
+        { defaultcolors: $3Dmol.elementColors.rasmol });
+    }
 
     const renderingSameModelData = moleculeUtils.modelDataEquivalent(
       this.oldModelData, this.props.modelData
@@ -160,6 +176,20 @@ class Molecule3d extends React.Component {
     if (!renderingSameModelData) {
       this.lastStylesByAtom = null;
       Molecule3d.render3dMolModel(glviewer, this.props.modelData);
+    }
+
+    if (this.props.outlineWidth !== this.lastOutline.width ||
+        this.props.outlineColor !== this.lastOutline.color) {
+      if (this.props.outlineWidth) {
+        this.lastOutline = {
+          style: 'outline',
+          width: this.props.outlineWidth,
+          color: this.props.outlineColor,
+        };
+      } else {
+        this.lastOutline = {};
+      }
+      glviewer.setViewStyle(this.lastOutline);
     }
 
     const styleUpdates = Object.create(null); // style update strings to atom ids needed
@@ -215,6 +245,14 @@ class Molecule3d extends React.Component {
     Molecule3d.render3dMolShapes(glviewer, this.props.shapes);
     Molecule3d.render3dMolOrbital(glviewer, this.props.orbital);
 
+    let customSlab = false;
+
+    if (typeof (this.props.nearClip) === 'number' &&
+        typeof (this.props.farClip) === 'number') {
+      glviewer.setSlab(this.props.nearClip, this.props.farClip);
+      customSlab = true;
+    }
+
     glviewer.setBackgroundColor(
       libUtils.colorStringToNumber(this.props.backgroundColor),
       this.props.backgroundOpacity
@@ -228,8 +266,9 @@ class Molecule3d extends React.Component {
       glviewer.zoomTo(0.8);
     }
 
+
     if (!renderingSameModelData) {
-      glviewer.fitSlab();
+      if (!customSlab) glviewer.fitSlab();
       this.props.onRenderNewData(glviewer);
     }
 

--- a/src/components/molecule_3d.jsx
+++ b/src/components/molecule_3d.jsx
@@ -160,15 +160,9 @@ class Molecule3d extends React.Component {
       return;
     }
 
-    let glviewer = null;
-
-    if (this.glviewer) {
-      glviewer = this.glviewer;
-    } else {
-      glviewer = $3Dmol.createViewer(
-        jQuery(this.container),
-        { defaultcolors: $3Dmol.elementColors.rasmol });
-    }
+    const glviewer = this.glviewer || $3Dmol.createViewer(jQuery(this.container), {
+      defaultcolors: $3Dmol.elementColors.rasmol,
+    });
 
     const renderingSameModelData = moleculeUtils.modelDataEquivalent(
       this.oldModelData, this.props.modelData

--- a/test/fixtures/factories.js
+++ b/test/fixtures/factories.js
@@ -20,6 +20,7 @@ const factories = {
       setBackgroundColor: () => {},
       setClickable: () => {},
       setStyle: () => {},
+      setViewStyle: () => {},
       zoom: () => {},
       zoomTo: () => {},
     };


### PR DESCRIPTION
3d shape outlines `props.outlineWidth` and `props.outlineColor`:
![image](https://user-images.githubusercontent.com/9388007/28731590-60418cc8-7389-11e7-96fd-c5e686234f75.png)

Clipping planes `props.nearClip` and `props.farClip`:
![clipping](https://user-images.githubusercontent.com/9388007/28731717-d69efbda-7389-11e7-9576-addbec7a4844.gif)
